### PR TITLE
Temat_9 Dodanie maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,18 @@ Na przykład: <suiteXmlFile>src\test\resources\all_tests_suite.xml</suiteXmlFile
 
 Uruchomienie dla ${testSuite} "mvn clean test -Dsurefire.suiteXmlFiles=src\test\resources\all_tests_suite.xml
 Dla twardeś ścieżki to: "mvn clean test" -->
-                        <suiteXmlFile>${testSuite}</suiteXmlFile>
+                        <suiteXmlFile>\src\test\resources\all_tests_suite.xml</suiteXmlFile>
                     </suiteXmlFiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -1,7 +1,7 @@
 app.url=http://przyklady.javastart.pl/jpetstore/
 
 browser=CHROME
-is.remote.run=false
+is.remote.run=true
 grid.url=http://192.168.0.101:4444/wd/hub
 
 chrome.driver.location=D:/Testowanie/ProjektyGIT/SeleniumCookbook/src/main/resources/chromedriver.exe

--- a/src/test/java/Rozdział_10_GRID/SeleniumGridExampleTest.java
+++ b/src/test/java/Rozdział_10_GRID/SeleniumGridExampleTest.java
@@ -18,7 +18,7 @@ public class SeleniumGridExampleTest {
 /** Uruchomienie HUBa: java -jar selenium-server-4.1.3.jar hub
  * Uruchomienie NODa: java -Dwebdriver.chrome.driver=D:\Testowanie\ProjektyGIT\SeleniumCookbook\src\main\resources\chromedriver.exe  -jar selenium-server-4.1.3.jar node*/
 
-// Z ustawieniami: -jar selenium-server-4.1.3.jar node --config D:\Programy\SeleniumGridNode\NodeConfiguration.toml
+// Z ustawieniami: java -Dwebdriver.chrome.driver=D:\Testowanie\ProjektyGIT\SeleniumCookbook\src\main\resources\chromedriver.exe  -jar selenium-server-4.1.3.jar node --config D:\Programy\SeleniumGridNode\NodeConfiguration.toml
     private WebDriver driver;
 
     @BeforeMethod

--- a/target/classes/configuration.properties
+++ b/target/classes/configuration.properties
@@ -2,9 +2,7 @@ app.url=http://przyklady.javastart.pl/jpetstore/
 
 browser=CHROME
 is.remote.run=true
-
 grid.url=http://192.168.0.101:4444/wd/hub
-#grid.url=http://192.168.1.6:4444/wd/hub
 
 chrome.driver.location=D:/Testowanie/ProjektyGIT/SeleniumCookbook/src/main/resources/chromedriver.exe
 firefox.driver.location=D:/Testowanie/ProjektyGIT/SeleniumCookbook/src/main/resources/geckodriver.exe


### PR DESCRIPTION
Dodanie pluginu i jego konfiguracja.
Dzięki zastosowaniu maven-compiler-plugin oraz zadania odpowiedniej konfiguracji w tagu <configuration> w pliku pom.xml framework będzie kompilowany zawsze dla wersji Javy 16. Niezależnie od ustawień lokalnych danej maszyny. Przez dodanie pluginu maven-compiler-plugin dbamy o to, aby projekt testów zawsze był komplikowany dla wybranej przez nas wersji Javy bez znaczenia na konfigurację środowiska uruchomieniowego.