### PR TITLE
Temat_9 Zastosowanie BasePage

### DIFF
--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/AngelfishListPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/AngelfishListPage.java
@@ -2,15 +2,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class AngelfishListPage {
-
-    private Logger logger = LogManager.getLogger(AngelfishListPage.class);
+public class AngelfishListPage extends BasePage{
 
     @FindBy(css = "a.Button[href$=\"EST-1\"]")
     private WebElement addToCardLargeAngelfishButton;
@@ -25,14 +21,14 @@ public class AngelfishListPage {
     public ShoppingCartPage clickOnAddToCardLargeAngelfish() {
         WaitForElement.waitUntilElementIsVisible(addToCardLargeAngelfishButton);
         addToCardLargeAngelfishButton.click();
-        logger.info("Clicked on add to card large Angelfish button");
+        log().info("Clicked on add to card large Angelfish button");
         return new ShoppingCartPage();
     }
 
     public void clickOnAddToCardSmallAngelfish() {
         WaitForElement.waitUntilElementIsVisible(addToCardSmallAngelfishButton);
         addToCardSmallAngelfishButton.click();
-        logger.info("Clicked on add to card small Angelfish button");
+        log().info("Clicked on add to card small Angelfish button");
     }
 
 

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/AnimalsCategoryPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/AnimalsCategoryPage.java
@@ -2,15 +2,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class AnimalsCategoryPage {
-
-    private Logger logger = LogManager.getLogger(AnimalsCategoryPage.class);
+public class AnimalsCategoryPage extends BasePage{
 
     @FindBy(css = "a[href$=\"Id=FISH\"]")
     private WebElement fishButton;
@@ -35,31 +31,31 @@ public class AnimalsCategoryPage {
     public FishListPage clickOnFishCategory() {
         WaitForElement.waitUntilElementIsClickable(fishButton);
         fishButton.click();
-        logger.info("Clicked on Fish button");
+        log().info("Clicked on Fish button");
         return new FishListPage();
     }
 
     public void clickOnDogsCategory() {
         WaitForElement.waitUntilElementIsClickable(dogsButton);
         dogsButton.click();
-        logger.info("Clicked on Dogs button");
+        log().info("Clicked on Dogs button");
     }
 
     public void clickOnCatsCategory() {
         WaitForElement.waitUntilElementIsClickable(catsButton);
         catsButton.click();
-        logger.info("Clicked on Cats button");
+        log().info("Clicked on Cats button");
     }
 
     public void clickOnReptiliesCategory() {
         WaitForElement.waitUntilElementIsClickable(reptiliesButton);
         reptiliesButton.click();
-        logger.info("Clicked on Reptilies button");
+        log().info("Clicked on Reptilies button");
     }
 
     public void clickOnBirdsCategory() {
         WaitForElement.waitUntilElementIsClickable(birdsButton);
         birdsButton.click();
-        logger.info("Clicked on Birds button");
+        log().info("Clicked on Birds button");
     }
 }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/BasePage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/BasePage.java
@@ -1,0 +1,19 @@
+package JavaStartSeleniumRozdzial_9.page.objects;
+
+import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.support.PageFactory;
+
+public abstract class BasePage {
+
+    private Logger logger = LogManager.getLogger(this.getClass().getName());
+
+    public BasePage() {
+        PageFactory.initElements(DriverManager.getWebDriver(), this);
+    }
+
+    protected Logger log() {
+        return logger;
+    }
+}

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FishListPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FishListPage.java
@@ -2,15 +2,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class FishListPage {
-
-    Logger logger = LogManager.getRootLogger();
+public class FishListPage extends BasePage{
 
     @FindBy(css = "a[href$=\"=FI-SW-01\"]")
     private WebElement angelfishIdButton;
@@ -32,25 +28,25 @@ public class FishListPage {
     public AngelfishListPage clickOnAngelfishIdButton() {
         WaitForElement.waitUntilElementIsVisible(angelfishIdButton);
         angelfishIdButton.click();
-        logger.info("Clicked AngelfishID button");
+        log().info("Clicked AngelfishID button");
         return new AngelfishListPage();
     }
 
     public void clickOnTigerSharkIdButton() {
         WaitForElement.waitUntilElementIsClickable(tigerSharkIdButton);
         tigerSharkIdButton.click();
-        logger.info("Clicked on TigerSharkID button");
+        log().info("Clicked on TigerSharkID button");
     }
 
     public void clickOnKoiIdButtonIdButton() {
         WaitForElement.waitUntilElementIsClickable(koiIdButton);
         koiIdButton.click();
-        logger.info("Clicked on KoiID button");
+        log().info("Clicked on KoiID button");
     }
 
     public void clickOnGoldfishIdButton() {
         WaitForElement.waitUntilElementIsClickable(goldfishIdButton);
         goldfishIdButton.click();
-        logger.info("Clicked on GoldfishID button");
+        log().info("Clicked on GoldfishID button");
     }
 }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FooterPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/FooterPage.java
@@ -3,17 +3,13 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import io.qameta.allure.Step;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
 import static JavaStartSeleniumRozdzial_9.generic.assertions.AssertWebElement.assertThat;
 
-public class FooterPage {
-
-    private Logger logger = LogManager.getLogger(FooterPage.class);
+public class FooterPage extends BasePage{
 
     @FindBy(css = "#Banner img[src*='dog']")
     private WebElement bannerAfterLoginLogo;
@@ -24,7 +20,7 @@ public class FooterPage {
 
     @Step("Assert that element dog banner is displayed")
     public FooterPage assertThatDogBannerIsDisplayed(){
-        logger.info("Checking if dog banner is displayed");
+        log().info("Checking if dog banner is displayed");
         WaitForElement.waitUntilElementIsVisible(bannerAfterLoginLogo);
         assertThat(bannerAfterLoginLogo).isDisplayed();
         return this;

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LandingPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LandingPage.java
@@ -3,15 +3,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import io.qameta.allure.Step;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class LandingPage {
-
-    private Logger logger = LogManager.getLogger(LandingPage.class);
+public class LandingPage extends BasePage{
 
     @FindBy(css = "#Content a")
     private WebElement enterStoreLink;
@@ -24,7 +20,7 @@ public class LandingPage {
     public TopMenuPage clickOnEnterStoreLink() {
         WaitForElement.waitUntilElementIsClickable(enterStoreLink);
         enterStoreLink.click();
-        logger.info("Clicked on Enter Store link");
+        log().info("Clicked on Enter Store link");
         return new TopMenuPage();
     }
 }

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LoginPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/LoginPage.java
@@ -4,15 +4,11 @@ import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.generic.assertions.AssertWebElement;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import io.qameta.allure.Step;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class LoginPage {
-
-    private Logger logger = LogManager.getLogger(LoginPage.class);
+public class LoginPage extends BasePage {
 
     @FindBy(name = "username")
     private WebElement usernameField;
@@ -37,7 +33,7 @@ public class LoginPage {
     public LoginPage typeIntoUserNameField(String username) {
         WaitForElement.waitUntilElementIsVisible(usernameField);
         usernameField.sendKeys(username);
-        logger.info("Typed into User Name Field {}", username);
+        log().info("Typed into User Name Field {}", username);
         return this;
     }
 
@@ -45,20 +41,20 @@ public class LoginPage {
     public LoginPage typeIntoPasswordField(String password) {
         passwordField.clear();
         passwordField.sendKeys(password);
-        logger.info("Typed into Password Field {}", password);
+        log().info("Typed into Password Field {}", password);
         return this;
     }
 
     @Step("Click on Login Button")
     public FooterPage clickOnLoginButton() {
         signOnButton.click();
-        logger.info("Clicked on Login Button");
+        log().info("Clicked on Login Button");
         return new FooterPage();
     }
 
     @Step("Assert that warning message {warningMessage} is displayed")
     public LoginPage assertThatWarningIsDisplayed(String warningMessage) {
-        logger.info("Checking if warning message {} is displayed", warningMessage);
+        log().info("Checking if warning message {} is displayed", warningMessage);
         WaitForElement.waitUntilElementIsVisible(messageLabel);
         AssertWebElement.assertThat(messageLabel).isDisplayed().hasText(warningMessage);
         return this;
@@ -66,7 +62,7 @@ public class LoginPage {
 
     @Step("Assert ")
     public LoginPage assertVisibilityOfWarningMessageAfterProceedChceckoutAsNotLoggedUser(String warningMessage){
-        logger.info("Checking if warning message {} is displayed", warningMessage);
+        log().info("Checking if warning message {} is displayed", warningMessage);
         WaitForElement.waitUntilElementIsVisible(messageLabel);
         AssertWebElement.assertThat(messageLabel).isDisplayed().hasText(warningMessage);
         return this;

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/ShoppingCartPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/ShoppingCartPage.java
@@ -2,15 +2,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class ShoppingCartPage {
-
-    private Logger logger = LogManager.getLogger(ShoppingCartPage.class);
+public class ShoppingCartPage extends BasePage{
 
     @FindBy(css = "a[href$=\"newOrderForm=\"]")
     private WebElement proceedToCheckoutButton;
@@ -22,7 +18,7 @@ public class ShoppingCartPage {
     public CheckoutPage clickOnProceedToCheckout(){
         WaitForElement.waitUntilElementIsVisible(proceedToCheckoutButton);
         proceedToCheckoutButton.click();
-        logger.info("Clicked on Proceed to Checkout Button");
+        log().info("Clicked on Proceed to Checkout Button");
         return new CheckoutPage();
     }
 

--- a/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/TopMenuPage.java
+++ b/src/test/java/JavaStartSeleniumRozdzial_9/page/objects/TopMenuPage.java
@@ -3,15 +3,11 @@ package JavaStartSeleniumRozdzial_9.page.objects;
 import JavaStartSeleniumRozdzial_9.driver.manager.DriverManager;
 import JavaStartSeleniumRozdzial_9.waits.WaitForElement;
 import io.qameta.allure.Step;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 
-public class TopMenuPage {
-
-    private Logger logger = LogManager.getLogger(TopMenuPage.class);
+public class TopMenuPage extends BasePage {
 
     @FindBy(css = "#MenuContent a[href*='signonForm']")
     private WebElement signOnLink;
@@ -24,7 +20,7 @@ public class TopMenuPage {
     public LoginPage clickOnSignInLink() {
         WaitForElement.waitUntilElementIsClickable(signOnLink);
         signOnLink.click();
-        logger.info("Clicked on Sign on Link");
+        log().info("Clicked on Sign on Link");
         return new LoginPage();
     }
 }


### PR DESCRIPTION
Zmiany, które wykonaliśmy nie wpłynęły na wynik testów. To co zmieniło się to fakt usunięcia duplikacji strukturalnej w kodzie Page Objectów.

Ale jak to w takim razie możliwe, że po usunięciu konstruktora z klas podrzędnych na przykład LoginPage dalej inicjalizują się WebElementy? Przecież żadna z klas teraz niema wywołania metody initElements(). Odpowiedz na to pytanie leży w kolejności tworzenia obiektów, które mają rodziców. W Javie jeśli klasa podrzędna nie ma konstruktora domyślnego (bez parametrowego) to w momencie utworzenia obiektu tej klasy wywoływany jest najpierw konstruktor z klasy rodzica, aż do klasy Object, która jest najwyższą klasą w Javie.
Krótko mówiąc jeśli tworzymy obiektLoginPage loginPage = new LoginPage();
To najpierw wywołujemy konstruktor z klasy nadrzędnej – czyli klasy BasePage. W konstruktorze tym znajduje się wywołanie metody initElements(), które powoduje inicjalizację WebElementów na stronie. Dodatkowo, ponieważ stosujemy słowo kluczowe this odwołujemy się do klasy, która go utworzyła czyli w opisanym przykładzie LoginPage.